### PR TITLE
Remove byebug reference

### DIFF
--- a/lib/drg/tasks/gemfile_line.rb
+++ b/lib/drg/tasks/gemfile_line.rb
@@ -18,7 +18,7 @@ module DRG
       def remove_version
         swap_version('')
       end
-      require 'byebug'
+
       # @description Replaces the gem version with the given one
       # @example
       #


### PR DESCRIPTION
When running one of the rake tasks, for example:
```
bundle exec rake drg:pin:minor
```

the following error was raised
```
  Pinning Gemfile "/app/Gemfile"
rake aborted!
LoadError: cannot load such file -- byebug
/usr/local/bundle/gems/activesupport-4.2.11.1/lib/active_support/dependencies.rb:274:in `require'
/usr/local/bundle/gems/activesupport-4.2.11.1/lib/active_support/dependencies.rb:274:in `block in require'
/usr/local/bundle/gems/activesupport-4.2.11.1/lib/active_support/dependencies.rb:240:in `load_dependency'
/usr/local/bundle/gems/activesupport-4.2.11.1/lib/active_support/dependencies.rb:274:in `require'
/app/vendor/gems/drg/lib/drg/tasks/gemfile_line.rb:21:in `<class:GemfileLine>'
/app/vendor/gems/drg/lib/drg/tasks/gemfile_line.rb:3:in `<module:Tasks>'
/app/vendor/gems/drg/lib/drg/tasks/gemfile_line.rb:2:in `<module:DRG>'
/app/vendor/gems/drg/lib/drg/tasks/gemfile_line.rb:1:in `<top (required)>'
/usr/local/bundle/gems/activesupport-4.2.11.1/lib/active_support/dependencies.rb:274:in `require'
/usr/local/bundle/gems/activesupport-4.2.11.1/lib/active_support/dependencies.rb:274:in `block in require'
/usr/local/bundle/gems/activesupport-4.2.11.1/lib/active_support/dependencies.rb:240:in `load_dependency'
/usr/local/bundle/gems/activesupport-4.2.11.1/lib/active_support/dependencies.rb:274:in `require'
/app/vendor/gems/drg/lib/drg/tasks/gemfile.rb:31:in `block in find_by_name'
/app/vendor/gems/drg/lib/drg/tasks/gemfile.rb:26:in `each'
/app/vendor/gems/drg/lib/drg/tasks/gemfile.rb:26:in `each_with_index'
/app/vendor/gems/drg/lib/drg/tasks/gemfile.rb:26:in `each'
/app/vendor/gems/drg/lib/drg/tasks/gemfile.rb:26:in `find_by_name'
/app/vendor/gems/drg/lib/drg/tasks/pinner.rb:17:in `block in perform'
/app/vendor/gems/drg/lib/drg/tasks/pinner.rb:16:in `each'
/app/vendor/gems/drg/lib/drg/tasks/pinner.rb:16:in `perform'
/app/vendor/gems/drg/lib/tasks/drg.rake:17:in `block (3 levels) in <top (required)>'
/usr/local/bundle/gems/rake-13.0.1/exe/rake:27:in `<top (required)>'
/usr/local/bundle/gems/bundler-1.17.3/lib/bundler/cli/exec.rb:74:in `load'
/usr/local/bundle/gems/bundler-1.17.3/lib/bundler/cli/exec.rb:74:in `kernel_load'
/usr/local/bundle/gems/bundler-1.17.3/lib/bundler/cli/exec.rb:28:in `run'
/usr/local/bundle/gems/bundler-1.17.3/lib/bundler/cli.rb:463:in `exec'
/usr/local/bundle/gems/bundler-1.17.3/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/usr/local/bundle/gems/bundler-1.17.3/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
```
(This error was not raised if the project/app already had byebug as a required dependency)
